### PR TITLE
fix: corrige MathJax e melhora enunciados do cap3/mudanca-de-variaveis

### DIFF
--- a/exercicios/capitulo-3/massa-e-centro-de-massa/index.html
+++ b/exercicios/capitulo-3/massa-e-centro-de-massa/index.html
@@ -8,31 +8,7 @@
       href="https://fonts.cdnjs.com/css2?family=Share+Tech+Mono&amp;display=swap"
       rel="stylesheet"
     />
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script
-      async=""
-      id="MathJax-script"
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
-    ></script>
-    <script>
-      MathJax = {
-        tex: {
-          inlineMath: [
-            ['$', '$'],
-            ['\(', '\)'],
-          ],
-          displayMath: [
-            ['$$', '$$'],
-            ['\[', '\]'],
-          ],
-          processEscapes: true,
-          processEnvironments: true,
-        },
-        options: {
-          skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-        },
-      };
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
       :root {
         --main-bg-color: #0a0a0a;
@@ -391,8 +367,8 @@
             }
           }
 
-          if (window.MathJax && window.MathJax.Hub) {
-            MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+          if (window.MathJax && typeof MathJax.typeset === 'function') {
+            MathJax.typeset();
           }
         } catch (error) {
           console.error('Erro ao carregar exercícios:', error);

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0a.html
@@ -11,7 +11,8 @@
     Antes de calcular integrais com mudança de variáveis, precisamos dominar a
     linguagem das coordenadas polares. Cada ponto do plano pode ser descrito por
     uma distância \(r\) até a origem e um ângulo \(\theta\) medido a partir do
-    eixo \(x\). Este exercício fixa essa correspondência com um caso concreto.
+    eixo \(x\). Considere o ponto com coordenadas polares \(r=2\) e
+    \(\theta=\frac{\pi}{4}\).
   </p>
   <p>
     <strong>(a)</strong> Desenhe os eixos \(x\) e \(y\) e localize o ponto

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0a.html
@@ -25,11 +25,6 @@
     <strong>(c)</strong> Verifique que \(x^2 + y^2 = r^2\), confirmando a
     relação fundamental entre os dois sistemas.
   </p>
-  <p>
-    Considere coordenadas polares \((r,\theta)\) com \(r=2\) e
-    \(\theta=\frac{\pi}{4}\). Converta para coordenadas cartesianas \((x,y)\) e
-    verifique a relação \(x^2+y^2=r^2\).
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0b.html
@@ -23,11 +23,6 @@
     Depois, desenhe o quadrado \([0,1]\times[0,1]\) no plano \((u,v)\) e sua
     imagem no plano \((x,y)\). A imagem é um losango.
   </p>
-  <p>
-    Dada a transformação \[ \begin{cases} x = u + v \\ y = u - v \end{cases} \]
-    determine a imagem dos vértices do quadrado \([0,1]\times[0,1]\) no plano
-    \((u,v)\) e descreva a figura resultante no plano \((x,y)\).
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-0c.html
@@ -29,10 +29,6 @@
     retângulo \(dr \times d\theta\) em coordenadas polares tem área
     \(r\,dr\,d\theta\) no plano \(xy\).
   </p>
-  <p>
-    Calcule o Jacobiano \(J = \frac{\partial(x,y)}{\partial(r,\theta)}\) para
-    \(x = r\cos\theta\), \(y = r\sin\theta\) e demonstre que \(|J| = r\).
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1a.html
@@ -25,11 +25,6 @@
     <strong>(c)</strong> Resolva a integral resultante e verifique o valor
     numérico.
   </p>
-  <p>
-    Calcular \(\iint_{R} (x+2y)\,dx\,dy\) em que \(R\) é a região no primeiro
-    quadrante delimitada por \(x^2 + y^2 \le 4\). Use coordenadas polares para
-    efetuar a mudança de variáveis.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1a.html
@@ -9,9 +9,11 @@
   <p>
     Nos Exercícios 1-3, aprendemos a converter pontos para coordenadas polares e
     calculamos o Jacobiano \(J=r\). Agora aplicamos esses conceitos para avaliar
-    integrais. O primeiro passo é entender como coordenadas polares convertem o
-    disco em um retângulo no plano \((r,\theta)\), onde o fator \(r\)
-    (Jacobiano) corrige a distorção de área.
+    a integral \(\iint_{R} (x+2y)\,dx\,dy\), onde \(R\) é a região no primeiro
+    quadrante delimitada por \(x^2 + y^2 \le 4\) — um quarto de disco de raio 2.
+    O primeiro passo é entender como coordenadas polares convertem essa região
+    em um retângulo no plano \((r,\theta)\), onde o fator \(r\) (Jacobiano)
+    corrige a distorção de área.
   </p>
   <p>
     <strong>(a)</strong> Identifique os limites de \(r\) e \(\theta\) que

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1b.html
@@ -26,12 +26,6 @@
     <strong>(c)</strong> Resolva a integral e compare com o resultado obtido
     diretamente em coordenadas cartesianas.
   </p>
-  <p>
-    Seja \(\iint_{R} (3x - y)\,dx\,dy\) onde a região \(R\) é descrita em termos
-    das variáveis \(u\) e \(v\) pela transformação \[ \begin{cases} x = u + 1 \\
-    y = v - 2 \end{cases} \] com \(0 \le u \le 2\) e \(1 \le v \le 3\). Calcule
-    a integral via mudança de variáveis.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1b.html
@@ -9,8 +9,10 @@
   <p>
     Nos Exercícios 1-3, vimos que o Jacobiano de uma transformação mede o fator
     de escala de área. Nem toda mudança de variáveis envolve coordenadas
-    polares. Uma translação \(x=u+1,\; y=v-2\) desloca o sistema de coordenadas
-    sem alterar áreas — o Jacobiano é 1 (como calculado no Exercício 3). Este
+    polares. Considere a translação \(x=u+1,\; y=v-2\), que desloca o sistema de
+    coordenadas sem alterar áreas — o Jacobiano é 1 (como calculado no Exercício
+    3). Calcule \(\iint_{R} (3x - y)\,dx\,dy\) onde a região \(R\) é descrita
+    por \(0 \le u \le 2\) e \(1 \le v \le 3\) na nova parametrização. Este
     exercício mostra que o método é geral: vale para qualquer transformação
     diferenciável, não apenas para polares.
   </p>

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1c.html
@@ -9,10 +9,12 @@
   <p>
     Nos exercícios anteriores, vimos transformações com Jacobiano 1 (Exercício
     5) e Jacobiano \(r\) em coordenadas polares (Exercícios 1 e 3). Agora vamos
-    ver o caso em que uma reescala \(y=2v\) comprime o intervalo de \(y\), mas o
-    Jacobiano \(|\partial(x,y)/\partial(u,v)|=2\) compensa a contração,
-    preservando o valor da integral. Este mecanismo é o coração do método de
-    mudança de variáveis.
+    ver o caso em que uma reescala comprime o intervalo: sobre a região
+    \(R=\{(x,y) \mid 0 \le x \le 1,\; 0 \le y \le 2\}\), a função \(f(x,y)=x^2 +
+    xy\) será integrada usando a transformação \(u=x,\;v=y/2\). O Jacobiano
+    \(|\partial(x,y)/\partial(u,v)|=2\) compensa a contração, preservando o
+    valor da integral. Este mecanismo é o coração do método de mudança de
+    variáveis.
   </p>
   <p>
     <strong>(a)</strong> Determine o Jacobiano da transformação \(x=u\),

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-1c.html
@@ -26,12 +26,6 @@
     <strong>(c)</strong> Resolva a integral e confirme que o resultado é
     \(\frac{5}{3}\).
   </p>
-  <p>
-    Na região \(R\) dada por \(\{(x,y)\mid 0 \le x \le 1,\; 0 \le y \le 2\}\),
-    considere a função \(f(x,y)=x^2 + xy\). Proponha uma transformação linear
-    simples \(u=x,\;v=y/2\). Calcule \(\iint_{R} f(x,y)\,dx\,dy\) por meio da
-    nova parametrização.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-1]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2a.html
@@ -5,11 +5,11 @@
     <span class="censored">SUPERVISIONADA</span>]
   </div>
   <p>
-    Com polares já dominados, podemos atacar regiões mais interessantes. Uma
-    coroa circular \(1\le x^2+y^2\le 4\) é naturalmente descrita por \(1\le r\le
-    2\) em coordenadas polares. Quando o integrando depende de \(r^2\), a
-    mudança torna-se especialmente poderosa porque a função se separa em \(r\) e
-    \(\theta\).
+    Com polares já dominados, podemos atacar regiões mais interessantes. Calcule
+    \(\iint_{R} e^{x^2+y^2}\,dx\,dy\) na coroa circular \(1 \le x^2 + y^2 \le
+    4\). Em coordenadas polares, essa região se torna naturalmente \(1\le r\le
+    2\), e o integrando \(e^{x^2+y^2}=e^{r^2}\) se separa em variáveis \(r\) e
+    \(\theta\) — o que torna a mudança especialmente poderosa.
   </p>
   <p>
     <strong>(a)</strong> Escreva a região em coordenadas polares e determine o

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2a.html
@@ -22,11 +22,6 @@
   <p>
     <strong>(c)</strong> Integre em \(\theta\) e apresente o resultado final.
   </p>
-  <p>
-    Calcular \(\iint_{R} e^{x^2+y^2}\,dx\,dy\), onde \(R\) é a coroa circular
-    \(1 \le x^2 + y^2 \le 4\). Transforme para coordenadas polares e apresente o
-    resultado.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-2]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2b.html
@@ -5,12 +5,12 @@
     <span class="censored">Estação</span> X
   </div>
   <p>
-    Uma elipse \(\frac{x^2}{4}+\frac{y^2}{9}\le 1\) não é um disco, mas uma
-    reescala \(x=2u,\; y=3v\) a transforma no círculo unitário. A vantagem: a
-    simetria radial do disco pode anular integrais que seriam difíceis de
-    calcular na elipse original. Este exercício mostra quando a mudança de
-    variáveis não apenas simplifica os limites, mas elimina o cálculo por
-    completo.
+    A elipse \(\frac{x^2}{4}+\frac{y^2}{9}\le 1\) não é um disco, mas a reescala
+    \(x=2u,\; y=3v\) a transforma no círculo unitário. Calcule \(\iint_{R}
+    (4xy)\,dx\,dy\) sobre essa elipse. A vantagem: a simetria radial do disco
+    pode anular integrais que seriam difíceis de calcular na elipse original.
+    Este exercício mostra quando a mudança de variáveis não apenas simplifica os
+    limites, mas elimina o cálculo por completo.
   </p>
   <p>
     <strong>(a)</strong> Proponha a transformação que leva a elipse ao disco

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2b.html
@@ -24,11 +24,6 @@
     <strong>(c)</strong> Conclua o valor da integral sem calculá-la
     explicitamente.
   </p>
-  <p>
-    Seja \(\iint_{R} (4xy)\,dx\,dy\) onde \(R\) é a elipse definida por
-    \(\frac{x^2}{4} + \frac{y^2}{9} \le 1\). Proponha uma mudança de variáveis
-    para que a região se converta em círculo unitário, e calcule a integral.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-2]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2c.html
@@ -24,12 +24,6 @@
     <strong>(c)</strong> Escreva a integral resultante e discuta se ela admite
     fechamento em funções elementares.
   </p>
-  <p>
-    Calcular \(\iint_{R} \ln(1 + x^2 + y^2)\,dx\,dy\) onde \(R\) é o triângulo
-    determinado pelos pontos \((0,0), (2,0), (2,2)\). Sugerir uma parametrização
-    que simplifique o cálculo em dois estágios, convertendo primeiro a base e
-    depois ajustando a altura.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-2]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-2c.html
@@ -7,11 +7,12 @@
     Pesquisa Interna
   </div>
   <p>
-    Nem sempre a região é descrita por uma equação simples. Um triângulo com
-    vértices em \((0,0)\), \((2,0)\) e \((2,2)\) tem fronteiras mistas: uma
-    vertical, uma horizontal e uma oblíqua. A parametrização \(x=u,\; y=vu\)
-    converte a hipotenusa oblíqua em \(v=1\), retangularizando a região. Este
-    tipo de transformação aparece sempre que uma fronteira é uma reta inclinada.
+    Nem sempre a região é descrita por uma equação simples. Calcule \(\iint_{R}
+    \ln(1 + x^2 + y^2)\,dx\,dy\) sobre o triângulo com vértices em \((0,0)\),
+    \((2,0)\) e \((2,2)\). Essa região tem fronteiras mistas: uma vertical, uma
+    horizontal e uma oblíqua. A parametrização \(x=u,\; y=vu\) converte a
+    hipotenusa oblíqua em \(v=1\), retangularizando a região. Este tipo de
+    transformação aparece sempre que uma fronteira é uma reta inclinada.
   </p>
   <p>
     <strong>(a)</strong> Verifique que a transformação \(x=u\), \(y=vu\) leva o

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3a.html
@@ -7,11 +7,13 @@
     <span class="censored">Módulo Secreto</span> [Programa Gemini]
   </div>
   <p>
-    No exercício anterior, transformamos uma elipse em disco unitário e usamos
-    simetria para zerar a integral. Agora vamos testar se esse truque funciona
-    quando o integrando não é polinomial. A pergunta central: a função
-    \(\sin(x^2+y^2)\) é par ou ímpar após a mudança? Se não for, a integral não
-    se anula, mas a simplificação geométrica do disco ainda facilita o cálculo.
+    No exercício anterior, transformamos a elipse \(\frac{x^2}{4}+\frac{y^2}{9}
+    \le 1\) em disco unitário e usamos simetria para zerar a integral. Agora
+    vamos testar se esse truque funciona com um integrando não polinomial: sobre
+    a região elíptica \(\frac{x^2}{9} + \frac{y^2}{16} \le 1\), calcule \(\iint
+    f(x,y)\,dx\,dy\) com \(f(x,y) = \sin(x^2 + y^2)\). A pergunta central: essa
+    função é par ou ímpar após a mudança? Se não for, a integral não se anula,
+    mas a simplificação geométrica do disco ainda facilita o cálculo.
   </p>
   <p>
     <strong>(a)</strong> Proponha a transformação \(x=3u\), \(y=4v\) que leva a

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3a.html
@@ -25,12 +25,6 @@
     <strong>(c)</strong> Caso não haja anulação, escreva a integral final no
     disco unitário e justifique por que não se reduz a funções elementares.
   </p>
-  <p>
-    Dada a região elíptica \(\frac{x^2}{9} + \frac{y^2}{16} \le 1\), e a função
-    \(f(x,y) = \sin(x^2 + y^2)\), aplicar mudança de variáveis que converta a
-    elipse em \(\frac{u^2}{1} + \frac{v^2}{1} \le 1\) e avaliar a integral
-    resultante. Interprete se a integral pode ser zero por simetria ou não.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-3]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3b.html
@@ -26,12 +26,6 @@
     <strong>(c)</strong> Conclua por que a integral não admite solução em termos
     de funções elementares.
   </p>
-  <p>
-    Considere a integral \(\iint_{R} \cos(xy)\,dx\,dy\), onde \(R\) é a região
-    \(\{(x,y) \mid 1 \le x^2 + y^2 \le 9\}\). Utilize coordenadas polares para
-    avaliar possíveis simplificações e discuta se o resultado final é
-    diretamente integrável em termos de funções elementares.
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-3]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3b.html
@@ -7,9 +7,9 @@
   </div>
   <p>
     Até agora, coordenadas polares simplificaram nossas regiões e funções. Mas
-    nem sempre a mudança resolve tudo. Este exercício mostra um caso onde
-    polares convertem o domínio em faixas retangulares, mas o integrando
-    \(\cos(xy)\) se transforma em
+    nem sempre a mudança resolve tudo. Calcule \(\iint_{R} \cos(xy)\,dx\,dy\) na
+    coroa circular \(1 \le x^2 + y^2 \le 9\). Em polares, o domínio virará
+    faixas retangulares, mas o integrando se transforma em
     \(\cos\bigl(\frac{r^2}{2}\sin(2\theta)\bigr)\), que não se separa. A lição:
     a mudança de variáveis resolve o problema geométrico, mas a parte analítica
     pode permanecer difícil.

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3c.html
@@ -27,11 +27,6 @@
     <strong>(c)</strong> Escreva a integral transformada e discuta se admite
     fechamento em funções elementares.
   </p>
-  <p>
-    A região \(R\) está contida entre as retas \(y=0\) e \(y=2x\), e entre
-    \(x=0\) e \(x=2\). Defina uma transformação apropriada para "endireitar" a
-    faixa de integração e calcule \(\iint_{R} \sqrt{1 + x^2 + y^2}\,dx\,dy\).
-  </p>
   <details class="hint-container">
     <summary>ARQUIVO AUXILIAR [SIGMA-3]</summary>
     <div class="hint">

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-3c.html
@@ -8,11 +8,11 @@
   </div>
   <p>
     No exercício anterior, usamos uma parametrização não-linear \(x=u,\;y=vu\)
-    para retangularizar um triângulo. Agora vamos aplicar a mesma filosofia a
-    uma região cunha delimitada pelas retas \(y=0\) e \(y=2x\). A ideia é a
-    mesma: escolher variáveis que convertam a fronteira oblíqua em um limite
-    constante, transformando a região em um retângulo ou faixa simples no plano
-    \((u,v)\).
+    para retangularizar um triângulo. Agora aplicamos a mesma filosofia à região
+    delimitada pelas retas \(y=0\) e \(y=2x\), com \(0 \le x \le 2\). Calcule
+    \(\iint_{R} \sqrt{1 + x^2 + y^2}\,dx\,dy\) usando a transformação \(u=x\),
+    \(v=y/(2x)\), que converte a fronteira oblíqua em um limite constante,
+    transformando a região em um retângulo no plano \((u,v)\).
   </p>
   <p>
     <strong>(a)</strong> Proponha a transformação \(u=x\), \(v=y/(2x)\) e

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4a.html
@@ -7,11 +7,12 @@
   <p>
     Nos exercícios anteriores, usamos coordenadas polares para simplificar
     discos e coroas circulares. Agora combinamos essa técnica com uma restrição
-    angular: a região é o disco \(x^2+y^2\le 4\) intersectado com o semiplano
-    \(y\ge x\). Em coordenadas polares, a reta \(y=x\) define limites angulares
-    precisos, e o disco se torna simplesmente \(0\le r\le 2\). O desafio aqui é
-    que o integrando \(\exp(-x^2+y)\) não se separa após a mudança — a variável
-    angular aparece tanto em \(r^2\) quanto em \(r\).
+    angular: calcule \(\iint_{R} \exp(-x^2 + y)\,dx\,dy\) na região obtida pela
+    interseção entre \(x^2 + y^2 \le 4\) e \(y \ge x\). Em coordenadas polares,
+    a reta \(y=x\) define limites angulares precisos, e o disco se torna
+    simplesmente \(0\le r\le 2\). O desafio aqui é que o integrando
+    \(\exp(-x^2+y)\) não se separa após a mudança — a variável angular aparece
+    tanto em \(r^2\) quanto em \(r\).
   </p>
   <p>
     <strong>(a)</strong> Converta a região para coordenadas polares,

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4a.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4a.html
@@ -25,10 +25,6 @@
     <strong>(c)</strong> Discuta por que a integral resultante não admite
     solução elementar e escreva a expressão final.
   </p>
-  <p>
-    Determinar \(\iint_{R} \exp(-x^2 + y)\,dx\,dy\) na região obtida pela
-    interseção entre \(x^2 + y^2 \le 4\) e \(y \ge x\).
-  </p>
   <!-- SEM DICAS PARA SÉRIE OMEGA -->
   <details>
     <summary>RELATÓRIO DE CÁLCULO [SIGMA-4 REQUERIDO]</summary>

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4b.html
@@ -27,12 +27,6 @@
     <strong>(c)</strong> Resolva a integral dupla resultante e apresente o valor
     final.
   </p>
-  <p>
-    Calcular \(\iint_{R} \sin(x + y)\,dx\,dy\) onde \(R\) se define pelos
-    vértices \((0,0), (3,0), (3,3)\) com exclusão da parte em que \(y < x\).
-    Proponha a mudança de variáveis apropriada para que a diagonal seja
-    convertida em um novo limite simples.
-  </p>
   <!-- SEM DICAS PARA SÉRIE OMEGA -->
   <details>
     <summary>RELATÓRIO DE CÁLCULO [SIGMA-4 REQUERIDO]</summary>

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4b.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4b.html
@@ -9,11 +9,11 @@
   <p>
     Nos exercícios anteriores, vimos que coordenadas polares simplificam regiões
     com simetria circular. Mas e quando a região é triangular com uma diagonal
-    como fronteira? A transformação \(u=x,\;v=y-x\) converte a hipotenusa
-    oblíqua \(y=x\) no eixo \(v=0\), retangularizando o domínio. Este exercício
-    aplica a mesma filosofia de "endireitar fronteiras" a uma função
-    trigonométrica, mostrando que a mudança de variáveis não é exclusiva de
-    coordenadas polares.
+    como fronteira? Calcule \(\iint_{R} \sin(x + y)\,dx\,dy\) onde \(R\) é a
+    região delimitada pelos vértices \((0,0)\), \((3,0)\) e \((3,3)\), acima da
+    reta \(y=x\). A transformação \(u=x,\;v=y-x\) converte a hipotenusa oblíqua
+    \(y=x\) no eixo \(v=0\), retangularizando o domínio. Este exercício mostra
+    que a mudança de variáveis não é exclusiva de coordenadas polares.
   </p>
   <p>
     <strong>(a)</strong> Proponha a transformação que diagonaliza a fronteira

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4c.html
@@ -25,12 +25,6 @@
     <strong>(c)</strong> Avalie a parte angular e conclua se o resultado é nulo
     ou não.
   </p>
-  <p>
-    Investigar o valor de \(\iint_{R} (x^2 - y^2)\,dx\,dy\), onde \(R\) é
-    definido em coordenadas polares como \(\{(r,\theta)\mid 0 \le r \le 2,\;
-    \frac{\pi}{6} \le \theta \le \frac{5\pi}{6}\}\). Discutir qualquer possível
-    simplificação e se o resultado é nulo ou não.
-  </p>
   <!-- SEM DICAS PARA SÉRIE OMEGA -->
   <details>
     <summary>RELATÓRIO DE CÁLCULO [SIGMA-4 REQUERIDO]</summary>

--- a/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4c.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/exercicio-vector-4c.html
@@ -8,10 +8,12 @@
   </div>
   <p>
     Encerramos este tópico com um exercício que combina coordenadas polares com
-    análise de simetria. A função \(x^2-y^2 = r^2\cos(2\theta)\) troca de sinal
-    quando \(\theta\) passa de \(\pi/4\) para \(3\pi/4\). Se o setor angular for
-    simétrico em relação a esses pontos, a integral se anula. Caso contrário,
-    sobra um valor não-nulo que revela a assimetria da região.
+    análise de simetria. Calcule \(\iint_{R} (x^2 - y^2)\,dx\,dy\) na região
+    definida em coordenadas polares por \(0 \le r \le 2\), \(\frac{\pi}{6} \le
+    \theta \le \frac{5\pi}{6}\). A função \(x^2-y^2 = r^2\cos(2\theta)\) troca
+    de sinal quando \(\theta\) passa de \(\pi/4\) para \(3\pi/4\). Se o setor
+    angular for simétrico em relação a esses pontos, a integral se anula. Caso
+    contrário, sobra um valor não-nulo que revela a assimetria da região.
   </p>
   <p>
     <strong>(a)</strong> Escreva \(x^2-y^2\) em coordenadas polares usando a

--- a/exercicios/capitulo-3/mudanca-de-variaveis/index.html
+++ b/exercicios/capitulo-3/mudanca-de-variaveis/index.html
@@ -8,31 +8,7 @@
       href="https://fonts.cdnjs.com/css2?family=Share+Tech+Mono&amp;display=swap"
       rel="stylesheet"
     />
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script
-      async=""
-      id="MathJax-script"
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
-    ></script>
-    <script>
-      MathJax = {
-        tex: {
-          inlineMath: [
-            ['$', '$'],
-            ['\(', '\)'],
-          ],
-          displayMath: [
-            ['$$', '$$'],
-            ['\[', '\]'],
-          ],
-          processEscapes: true,
-          processEnvironments: true,
-        },
-        options: {
-          skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-        },
-      };
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
       :root {
         --main-bg-color: #0a0a0a;
@@ -408,8 +384,8 @@
             }
           }
 
-          if (window.MathJax && window.MathJax.Hub) {
-            MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+          if (window.MathJax && typeof MathJax.typeset === 'function') {
+            MathJax.typeset();
           }
         } catch (error) {
           console.error('Erro ao carregar exercícios:', error);

--- a/exercicios/capitulo-3/revisao/index.html
+++ b/exercicios/capitulo-3/revisao/index.html
@@ -8,31 +8,7 @@
       href="https://fonts.cdnjs.com/css2?family=Share+Tech+Mono&amp;display=swap"
       rel="stylesheet"
     />
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script
-      async=""
-      id="MathJax-script"
-      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
-    ></script>
-    <script>
-      MathJax = {
-        tex: {
-          inlineMath: [
-            ['$', '$'],
-            ['\(', '\)'],
-          ],
-          displayMath: [
-            ['$$', '$$'],
-            ['\[', '\]'],
-          ],
-          processEscapes: true,
-          processEnvironments: true,
-        },
-        options: {
-          skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
-        },
-      };
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
       /* estilos iguais ao template original */
       :root {
@@ -350,8 +326,8 @@
             }
           }
 
-          if (window.MathJax && window.MathJax.Hub) {
-            MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+          if (window.MathJax && typeof MathJax.typeset === 'function') {
+            MathJax.typeset();
           }
         } catch (error) {
           console.error('Erro ao carregar exercícios:', error);


### PR DESCRIPTION
## Summary

- Corrige configuração MathJax nos 3 `index.html` do capítulo 3 (remove `async`, `polyfill.io`, config explícita com `$...$`/`$$...$$`, e troca API v2 por v3)
- Remove parágrafos formais redundantes nos 15 exercícios de mudança-de-variaveis — esses parágrafos repetiam o problema de forma desconectada da narrativa
- Mescla os dados concretos (integral, região, valores) de volta na narrativa de cada exercício, mantendo o fluxo: motivação → problema concreto → itens (a)(b)(c)

## Changes

| Arquivo | Mudança |
|---|---|
| `capitulo-3/*/index.html` (3 arquivos) | Correção MathJax: remove async, polyfill.io, config explícita; usa `MathJax.typeset()` |
| `capitulo-3/mudanca-de-variaveis/exercicio-vector-*.html` (15 arquivos) | Remove parágrafo formal redundante e mescla dados na narrativa |

## Testado

- MathJax renderiza corretamente com script simples (sem async, sem config)
- Enunciados completos e coerentes sem os parágrafos removidos